### PR TITLE
Add upgrade option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: sh
 
 before_script:
-  - wget "http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.3.7-5_amd64.deb"
-  - sudo dpkg -i "shellcheck_0.3.7-5_amd64.deb"
+  - wget "http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.4.4-2_amd64.deb"
+  - sudo dpkg -i "shellcheck_0.4.4-2_amd64.deb"
 
 script:
   - shellcheck *.sh

--- a/README.md
+++ b/README.md
@@ -9,3 +9,22 @@ added script to idempotently install it as a daily cron task.
 ```
 curl -fsS https://raw.githubusercontent.com/grantovich/homebrew-notifier/master/install.sh | sh
 ```
+
+Note: default behavior is to prompt for upgrades, if any are available. To
+change this, see usage below.
+
+##Usage
+Cron will execute the notifier script daily, which will check for any oudated,
+unpinned formulae.
+
+###Upgrade
+```
+--upgrade [prompt, auto]
+```
+Providing the upgrade option with a value of `prompt` (default) will cause the
+notifier to display a notification when updates are available. When this
+notification is clicked, these formulae will be upgraded. Providing a value of
+`auto` will cause these formulae to be updated automatically.
+
+After the upgrade process is complete, a notification will be displayed
+indicating if the upgrades succeeded or failed.

--- a/install.sh
+++ b/install.sh
@@ -3,19 +3,22 @@
 BASE_URL=https://raw.githubusercontent.com/grantovich/homebrew-notifier/master
 NOTIFIER_PATH=$HOME/.homebrew-notifier
 NOTIFIER_SCRIPT=$NOTIFIER_PATH/notifier.sh
+UPDATE_SCRIPT=$NOTIFIER_PATH/upgrade.sh
 
 brew list | grep -q "terminal-notifier" || brew install terminal-notifier
 mkdir -p "$NOTIFIER_PATH"
 curl -fsS $BASE_URL/notifier.sh > "$NOTIFIER_SCRIPT"
+curl -fsS $BASE_URL/upgrade.sh > "$UPDATE_SCRIPT"
 chmod +x "$NOTIFIER_SCRIPT"
+chmod +x "$UPDATE_SCRIPT"
 
 if crontab -l | grep -q "notifier\.sh"; then
   echo "Crontab entry already exists, skipping..."
 else
-  echo "0 11 * * * PATH=/usr/local/bin:\$PATH $NOTIFIER_SCRIPT" | crontab -
+  echo "0 11 * * * PATH=/usr/local/bin:\$PATH $NOTIFIER_SCRIPT --upgrade prompt" | crontab -
 fi
 
 echo
 echo "Notifier installed. You'll be notified of brew updates at 11am every day."
 echo "Checking for updates right now..."
-$NOTIFIER_SCRIPT
+$NOTIFIER_SCRIPT --upgrade prompt

--- a/notifier.sh
+++ b/notifier.sh
@@ -1,18 +1,48 @@
 #!/bin/bash
 
+UPGRADE="off"
+while [[ $# -ge 1 ]]
+do
+    key="$1"
+    case $key in
+        "--upgrade")
+            UPGRADE="$2"
+            shift
+            ;;
+        *)
+            # Unknown option
+            ;;
+    esac
+    shift
+done
+
 BREW=$(which brew)
 TERMINAL_NOTIFIER=$(which terminal-notifier)
+NOTIFIER_PATH=$HOME=/.homebrew-notifier
+UPGRADE_SCRIPT=$NOTIFIER_PATH/.upgrade.sh
+UPGRADE_COMMAND="PATH=/usr/local/bin:\$PATH $UPGRADE_SCRIPT"
 
 $BREW update > /dev/null 2>&1
 
 outdated=$($BREW outdated --quiet)
 pinned=$($BREW list --pinned)
-updatable=$(comm -1 -3 <(echo "$pinned") <(echo "$outdated"))
+updatable=$(comm -1 -3 <(echo "$pinned") <(echo "$outdated") | xargs)
 
 if [ -n "$updatable" ] && [ -e "$TERMINAL_NOTIFIER" ]; then
-    $TERMINAL_NOTIFIER -sender com.apple.Terminal \
-        -title "Homebrew Updates Available" \
-        -subtitle "The following formulae are outdated:" \
-        -message "$updatable" \
+    if [ "$UPGRADE" = "auto" ] && [ -f "$UPGRADE_SCRIPT" ]; then
+        $UPGRADE_SCRIPT "$updatable"
+    elif [ "$UPGRADE" = "prompt" ] && [ -f "$UPGRADE_SCRIPT" ]; then
+        $TERMINAL_NOTIFIER -sender com.apple.Terminal \¬
+        -title "Homebrew Updates Available" \¬
+        -subtitle "Click here to update the following formulae:" \¬
+        -message "$updatable" \¬
+        -sound default \¬
+        -execute "$UPGRADE_COMMAND $updatable"¬
+    else¬
+        $TERMINAL_NOTIFIER -sender com.apple.Terminal \¬
+        -title "Homebrew Updates Available" \¬
+        -subtitle "The following formulae are outdated:" \¬
+        -message "$updatable" \¬
         -sound default
+    fi
 fi

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+PACKAGES_TO_UPGRADE="$1"
+PACKAGE_COUNT="$#"
+BREW=$(which brew)
+TERMINAL_NOTIFIER=$(which terminal-notifier)
+
+if [ -n "$PACKAGES_TO_UPGRADE" ] && [ $PACKAGE_COUNT -gt 0 ]; then
+    $TERMINAL_NOTIFIER -sender com.apple.Terminal \
+        -title "Homebrew Updating..." \
+        -subtitle "Update in progress" \
+        -message "Updating $PACKAGE_COUNT formulae..."
+
+    $BREW upgrade $(echo -n "$PACKAGES_TO_UPGRADE")
+    BREW_UPGRADE_STATUS=$?
+fi
+
+if [ -n "$BREW_UPGRADE_STATUS" ]; then
+    if [ $BREW_UPGRADE_STATUS -eq 0 ]; then
+        $TERMINAL_NOTIFIER -sender com.apple.Terminal \
+            -title "Homebrew Updates Complete" \
+            -subtitle "Successfully updated the following formulae:" \
+            -message "$PACKAGES_TO_UPGRADE" \
+            -sound default \
+            -execute "say 🍺"
+    else
+        $TERMINAL_NOTIFIER -sender com.apple.Terminal \
+            -title "Homebrew Updates Failed" \
+            -subtitle "Failed to update some or all of the following formulae:" \
+            -message "$PACKAGES_TO_UPGRADE" \
+            -sound default
+    fi
+fi


### PR DESCRIPTION
This pull request adds the ability to perform an upgrade on the outdated packages detected.

Two possible parameters are provided for this option:
- `prompt` - Will display a notification to the user, which will execute the upgrade when clicked.
- `auto` - Will automatically upgrade the outdated packages, with no input required by the user.

Currently, I have the install script setting up `prompt` as the default option.

I am expecting the `shellcheck` script run by Travis-CI to show an error related to how I am providing upgrade arguments to brew; however, this is intentional. Brew must be provided with a split list of formulae, otherwise it will accept the list of formulae as a single argument and fail to upgrade. 
