### PR TITLE
Update shellcheck package to newest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: sh
 
 before_script:
-  - wget "http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.3.7-5_amd64.deb"
-  - sudo dpkg -i "shellcheck_0.3.7-5_amd64.deb"
+  - wget "http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.4.4-2_amd64.deb"
+  - sudo dpkg -i "shellcheck_0.4.4-2_amd64.deb"
 
 script:
   - shellcheck *.sh


### PR DESCRIPTION
The Travis build was failing due to the package for the specified version of shellcheck not existing anymore. I updated the URL to point to the new version.